### PR TITLE
Add PageStrike to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Everyone is welcome to submit their new Awesome low-code item.
 * [Bannerbear](https://www.bannerbear.com/) - Auto-generate social media visuals, ecommerce banners, dynamic email images and more with our API and integrations.
 * [Klaviyo](https://www.klaviyo.com/) - Ecommerce marketing automation platform.
 * [Datawave](https://datawave.app) - Startup Marketing Platform
+* [PageStrike](https://pagestrike.com) - AI landing page builder for marketing campaigns. Generates copy, photos, and lead capture form in 2 minutes. Native COD, 0% commission, 10+ languages including Arabic RTL.
 * [Place Card Maker](https://placecard.us) - A fast, easy and free printable place card maker,Design beautiful place cards in minutes with our free, user-friendly maker. Choose from 100+ customizable place cards templates, including options for meal choices. Perfect for weddings, holidays, and special events. Compatible with Microsoft Word for easy editing and printing.  No coding required
 
 ## Online database creator apps


### PR DESCRIPTION
## What this PR adds

Adds **PageStrike** to the Marketing section, alphabetically inserted between Klaviyo and Place Card Maker.

## Why it fits

PageStrike is an AI-first landing page builder built specifically for marketing campaigns. Marketing teams use it to:

- Run paid ad campaigns with conversion-optimized landing pages (Facebook, TikTok, Google Ads)
- Capture leads with built-in forms tied to a lifecycle CRM
- Spin up holiday / seasonal campaigns in minutes (Black Friday, Valentine's, product drops)
- Generate landing page copy + product photos via AI — no copywriter or designer required

Fits alongside existing Marketing entries (Klaviyo, Bannerbear, AppSumo, Datawave) as a tool that helps marketers ship campaigns faster.

Unique differentiators not present in any other entry in this list:

- Native cash-on-delivery checkout pipeline (MENA / Africa / SEA markets) — most US-built tools don't support COD at all
- 0% commission on Stripe/PayPal direct integration (vs ClickFunnels-style 3-30% cuts)
- Native AI generation in 10+ languages including Arabic RTL
- 6 dedicated CTA modes (buy now, COD, email capture, quote request, book a call, redirect)

## Disclosure

I'm the founder. Submitting myself since no one else has yet. Happy to adjust wording or category placement based on your preferences.

## Checklist

- [x] Entry placed in the Marketing section
- [x] Alphabetically inserted (between Klaviyo and Place Card Maker)
- [x] Description format matches existing entries
- [x] Product is live and functional (https://pagestrike.com)
- [x] No promotional fluff ("revolutionary", "best", etc.)
