### PR TITLE
Add Oinone — AI-native metadata-driven low-code framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Everyone is welcome to submit their new Awesome low-code item.
 * [Taskade](https://taskade.com) - Build custom AI agents, workflows, and apps using natural language. Multi-model AI platform with GPT, Claude, and Gemini support.
 * [Vertex-AI](https://cloud.google.com/vertex-ai) - Build, deploy, and scale machine learning (ML) models faster, with fully managed ML tools for any use case.
 * [Voiceflow](https://www.voiceflow.com/) - Build, launch, and scale advanced AI agents for support, lead generation, and beyond.
+* [Oinone](https://github.com/oinone/oinone-pamirs) - AI-native, 100% metadata/model-driven low-code framework where AI and developers share one metadata model. Built for complex enterprise scenarios, self-hostable. Open source (Java+TS, AGPL-3.0).
 
 ## Automation
 


### PR DESCRIPTION
Adding [Oinone](https://github.com/oinone/oinone-pamirs) under **AI**: an AI-native, 100% metadata/model-driven low-code framework where AI and developers collaborate on a single shared metadata model. Built for complex enterprise systems, self-hostable,信创-ready. Open source (Java + TypeScript, AGPL-3.0). Disclosure: contributor.