### PR TITLE
Add VibeKit.bot to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Everyone is welcome to submit their new Awesome low-code item.
 * [Sas](https://www.sas.com/en_si/software/machine-learning-cloud.html) - On-demand programming access to machine learning algorithms in the cloud.
 * [Taskade](https://taskade.com) - Build custom AI agents, workflows, and apps using natural language. Multi-model AI platform with GPT, Claude, and Gemini support.
 * [Vertex-AI](https://cloud.google.com/vertex-ai) - Build, deploy, and scale machine learning (ML) models faster, with fully managed ML tools for any use case.
+* [VibeKit.bot](https://vibekit.bot) - Build, host, and keep improving an app entirely from your phone. Each app gets a persistent AI coding agent that ships to a live domain, with BYOK for Claude/OpenAI or pay-as-you-go — driven from your phone or CLI.
 * [VNovels](https://vnovels.com) - A browser-based visual novel maker and platform: build branching, choice-based stories in a visual graph and scene editor with an AI story assistant, generate art, music and SFX with AI, and publish playable visual novels. No coding required.
 * [Voiceflow](https://www.voiceflow.com/) - Build, launch, and scale advanced AI agents for support, lead generation, and beyond.
 * [Oinone](https://github.com/oinone/oinone-pamirs) - AI-native, 100% metadata/model-driven low-code framework where AI and developers share one metadata model. Built for complex enterprise scenarios, self-hostable. Open source (Java+TS, AGPL-3.0).


### PR DESCRIPTION
Adds **VibeKit.bot** to the AI section, placed alphabetically between Vertex-AI and VNovels.

VibeKit.bot (https://vibekit.bot) is an AI app builder in the same vein as the section's existing entries (Forge, Playcode, Rosebud AI): each app gets a persistent AI coding agent that builds, hosts, and keeps improving it on a live domain — BYOK for Claude/OpenAI or pay-as-you-go, driven from a phone or CLI. Native iOS app on the App Store.

Format-matched to the section (`* [Name](url) - Description.`). Listed as "VibeKit.bot" to disambiguate from the unrelated `superagent-ai/vibekit` sandbox SDK.

Disclosure: I'm affiliated with VibeKit.