### PR TITLE
Change Convertigo platform description

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Everyone is welcome to submit their new Awesome low-code item.
 * [bubble](https://bubble.io/) - A code-free programming language that lets you build and host web applications without engineers.
 * [Carrd](https://carrd.co/) - Simple, free, fully responsive one-page sites for pretty much anything.
 * [Cloudscape](https://cloudscape.design/) - An open source design system for the cloud.
-* [Convertigo](https://www.convertigo.com/) - An Enterprise open source LowCode Platform to build Web & mobile apps
+* [Convertigo](https://www.convertigo.com/) - Open-source enterprise low-code platform for building web and mobile applications, backend workflows, and integrations.
 * [Dronahq](https://www.dronahq.com) - Build business apps without coding.
 * [Dynaboard](https://dynaboard.com) - Build production-ready low-code web apps in 60 seconds using AI.
 * [Heyflow](https://heyflow.app/) - Build interactive flows.


### PR DESCRIPTION
Updates the existing Convertigo entry to describe its current full-stack capabilities and use consistent low-code wording. No new link is introduced.

Project source: https://github.com/convertigo/convertigo

Disclosure: I am affiliated with Convertigo.