### PR TITLE
Add Erupt (annotation-driven Java admin framework / AI harness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Everyone is welcome to submit their new Awesome low-code item.
 * [AutoGen](https://github.com/microsoft/autogen) - AutoGen is a framework that enables the development of LLM applications using multiple agents that can converse with each other to solve tasks.
 * [Cliprun](https://cliprun.com/) - Create and schedule AI-generated Python scripts with one click.
 * [Dataiku](https://www.dataiku.com/product/key-capabilities/machine-learning) - Build advanced machine learning models using the latest techniques.
+* [Erupt](https://github.com/erupts/erupt) - Annotation-driven Java/Spring Boot admin framework and AI harness. One annotated JPA entity becomes a full admin page with RBAC, Excel import/export and OpenAPI; ships 50+ LLM providers, MCP-native tools and A2A agents configurable from the admin UI. Self-hostable, open source (Java, Apache-2.0).
 * [FlyonUI MCP](https://flyonui.com/mcp) - Integrate FlyonUI MCP - Tailwind AI Builder directly into your IDE and craft stunning Tailwind CSS Components, Blocks and Pages inspired by FlyonUI.
 * [Forge](https://forge-web.rebaselabs.online/) - AI-powered full-stack app creator. BYOK (bring your own API key) with Anthropic, OpenAI, or Google AI. Multi-stage pipeline generates SSR-first Next.js applications.
 * [DataRobot](https://www.datarobot.com/platform/visual-ai/) - DataRobot Automated Machine Learning with Visual AI.


### PR DESCRIPTION
Erupt is an Apache-2.0, annotation-driven Java/Spring Boot framework: annotate a JPA entity and get a full admin page - no controllers, no front-end build. It also works as an AI harness, with 50+ LLM providers, MCP-native tool exposure and A2A agents configurable from the admin UI.

Repo: https://github.com/erupts/erupt
Docs: https://docs.erupt.xyz
Live demo: https://demo.erupt.xyz
Maven Central: xyz.erupt:erupt

Placed under AI, alongside Oinone as the nearest comparable (metadata/model-driven, self-hostable, Java). Single line added, no other changes.